### PR TITLE
fix:add UTF-8 for html

### DIFF
--- a/lib/renderer-html.js
+++ b/lib/renderer-html.js
@@ -15,6 +15,7 @@ const PageHeader = `<!DOCTYPE html>
   <head>
     <title><!--TITLE--></title>
     <link rel="stylesheet" type="text/css" href="/static/style.css">
+    <meta charset="UTF-8"> 
     <meta property="og:title" content="<!--TITLE-->"/>
     <meta property="og:description" content="<!--DESCRIPTION-->"/>
     <!--SOCIAL_IMAGE

--- a/src.ts/renderer-html.ts
+++ b/src.ts/renderer-html.ts
@@ -16,6 +16,7 @@ const PageHeader = `<!DOCTYPE html>
   <head>
     <title><!--TITLE--></title>
     <link rel="stylesheet" type="text/css" href="/static/style.css">
+    <meta charset="UTF-8"> 
     <meta property="og:title" content="<!--TITLE-->"/>
     <meta property="og:description" content="<!--DESCRIPTION-->"/>
     <!--SOCIAL_IMAGE


### PR DESCRIPTION
为使得页面正常显示中文，在html中添加UTF-8属性标签